### PR TITLE
Support SA impersonation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,36 @@ See the [Google Cloud documentation](https://cloud.google.com/docs/authenticatio
 ```bash
 # Start MCP proxy
 npx mcp-gcloud-adc-proxy --url https://your-cloud-run-service.run.app
+
+# With service account impersonation
+npx mcp-gcloud-adc-proxy --url https://your-cloud-run-service.run.app --impersonate-service-account sa@project.iam.gserviceaccount.com
+
+# With custom audience
+npx mcp-gcloud-adc-proxy --url https://your-cloud-run-service.run.app --audiences https://example.com
+```
+
+### Service Account Impersonation
+
+You can use service account impersonation to generate ID tokens for a specific service account instead of using the default ADC credentials:
+
+```bash
+npx mcp-gcloud-adc-proxy \
+  --url https://your-cloud-run-service.run.app \
+  --impersonate-service-account your-sa@your-project.iam.gserviceaccount.com
+```
+
+**Requirements:**
+- The ADC principal must have the `roles/iam.serviceAccountTokenCreator` role on the target service account
+- The target service account must have the necessary permissions to access the remote MCP server
+
+### Custom Audience
+
+By default, the target URL is used as the audience for the ID token. You can override this with the `--audiences` option:
+
+```bash
+npx mcp-gcloud-adc-proxy \
+  --url https://your-cloud-run-service.run.app \
+  --audiences https://custom-audience.example.com
 ```
 
 ### Setup to Claude Code
@@ -41,6 +71,9 @@ claude mcp add foobar -s user -- npx -y mcp-gcloud-adc-proxy -u https://foobar.r
 
 # Or add to project scope to share with your team
 claude mcp add foobar -s project -- npx -y mcp-gcloud-adc-proxy -u https://foobar.run.app
+
+# With service account impersonation
+claude mcp add foobar -s user -- npx -y mcp-gcloud-adc-proxy -u https://foobar.run.app --impersonate-service-account sa@project.iam.gserviceaccount.com
 ```
 
 ## License

--- a/README_ja.md
+++ b/README_ja.md
@@ -29,6 +29,36 @@ export GOOGLE_APPLICATION_CREDENTIALS="path/to/service-account.json"
 ```bash
 # MCPプロキシを起動
 npx mcp-gcloud-adc-proxy --url https://your-cloud-run-service.run.app
+
+# サービスアカウントインパーソネーションを使用
+npx mcp-gcloud-adc-proxy --url https://your-cloud-run-service.run.app --impersonate-service-account sa@project.iam.gserviceaccount.com
+
+# カスタムオーディエンスを指定
+npx mcp-gcloud-adc-proxy --url https://your-cloud-run-service.run.app --audiences https://example.com
+```
+
+### サービスアカウントインパーソネーション
+
+デフォルトのADCクレデンシャルの代わりに、特定のサービスアカウントのIDトークンを生成するために、サービスアカウントインパーソネーションを使用できます：
+
+```bash
+npx mcp-gcloud-adc-proxy \
+  --url https://your-cloud-run-service.run.app \
+  --impersonate-service-account your-sa@your-project.iam.gserviceaccount.com
+```
+
+**要件:**
+- ADCプリンシパルは、対象のサービスアカウントに対して `roles/iam.serviceAccountTokenCreator` ロールを持っている必要があります
+- 対象のサービスアカウントは、リモートMCPサーバーにアクセスするための必要な権限を持っている必要があります
+
+### カスタムオーディエンス
+
+デフォルトでは、ターゲットURLがIDトークンのオーディエンスとして使用されます。`--audiences` オプションでこれを上書きできます：
+
+```bash
+npx mcp-gcloud-adc-proxy \
+  --url https://your-cloud-run-service.run.app \
+  --audiences https://custom-audience.example.com
 ```
 
 ### Claude Codeへの設定
@@ -39,6 +69,9 @@ claude mcp add foobar -s user -- npx -y mcp-gcloud-adc-proxy -u https://foobar.r
 
 # またはプロジェクトスコープに追加してチームと共有
 claude mcp add foobar -s project -- npx -y mcp-gcloud-adc-proxy -u https://foobar.run.app
+
+# サービスアカウントインパーソネーションを使用
+claude mcp add foobar -s user -- npx -y mcp-gcloud-adc-proxy -u https://foobar.run.app --impersonate-service-account sa@project.iam.gserviceaccount.com
 ```
 
 ## ライセンス

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-gcloud-adc-proxy",
   "description": "An auth proxy for accessing remote MCP servers using Google Cloud Application Default Credentials (ADC)",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "keywords": [
     "mcp",
     "model context protocol",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-gcloud-adc-proxy",
   "description": "An auth proxy for accessing remote MCP servers using Google Cloud Application Default Credentials (ADC)",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "keywords": [
     "mcp",
     "model context protocol",

--- a/src/libs/auth/google-auth.test.ts
+++ b/src/libs/auth/google-auth.test.ts
@@ -216,4 +216,62 @@ describe("createAuthClient", () => {
     expect(typeof client.getIdToken).toBe("function");
     expect(typeof client.refreshToken).toBe("function");
   });
+
+  it("サービスアカウント設定でクライアントを作成する", () => {
+    const config: AuthConfig = {
+      serviceAccountEmail: "test-sa@project.iam.gserviceaccount.com",
+    };
+
+    const client = createAuthClient(config);
+    expect(client).toBeTruthy();
+    expect(typeof client.getIdToken).toBe("function");
+    expect(typeof client.refreshToken).toBe("function");
+  });
+});
+
+describe.skip("サービスアカウントインパーソネーション", () => {
+  it("サービスアカウントが指定された場合、インパーソネーションを使用する", async () => {
+    const config: AuthConfig = {
+      serviceAccountEmail: "test-sa@project.iam.gserviceaccount.com",
+    };
+
+    const client = createAuthClient(config);
+    const result = await client.getIdToken("https://example.com");
+
+    // 実装されるまでこのテストは失敗する
+    expect(result.type).toBe("success");
+    if (result.type === "success") {
+      expect(typeof result.token).toBe("string");
+      expect(result.token.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("サービスアカウントが空文字の場合、通常のADCを使用する", async () => {
+    const config: AuthConfig = {
+      serviceAccountEmail: "",
+    };
+
+    const client = createAuthClient(config);
+    const result = await client.getIdToken("https://example.com");
+
+    // 空文字の場合は通常のADC処理
+    expect(result.type === "success" || result.type === "error").toBe(true);
+  });
+
+  it("不正なサービスアカウントメールでエラーを返す", async () => {
+    const config: AuthConfig = {
+      serviceAccountEmail: "invalid-email-format",
+    };
+
+    const client = createAuthClient(config);
+    const result = await client.getIdToken("https://example.com");
+
+    // インパーソネーション実装後、適切なエラーが返されることを検証
+    expect(result.type).toBe("error");
+    if (result.type === "error") {
+      expect(result.error.kind).toMatch(
+        /token-fetch-failed|impersonation-failed/,
+      );
+    }
+  });
 });

--- a/src/libs/auth/google-auth.ts
+++ b/src/libs/auth/google-auth.ts
@@ -10,9 +10,20 @@ import type {
 type GoogleAuthState = {
   googleAuth: GoogleAuth;
   tokenCache: TokenCache;
+  serviceAccountEmail?: string;
+  includeEmail: boolean;
 };
 
-const isValidAudience = (audience: string): boolean => {
+const isValidAudience = (
+  audience: string,
+  serviceAccountEmail?: string,
+): boolean => {
+  // サービスアカウントインパーソネーション使用時は、Client IDなどの非URL形式も許可
+  if (serviceAccountEmail) {
+    return audience.trim().length > 0;
+  }
+
+  // 通常のADC使用時はHTTPS URLのみ許可
   try {
     const url = new URL(audience);
     return url.protocol === "https:";
@@ -56,12 +67,150 @@ const extractTokenExpiration = (token: string): Date => {
   return new Date(Date.now() + 60 * 60 * 1000);
 };
 
+const fetchTokenWithImpersonation = async (
+  state: GoogleAuthState,
+  audience: string,
+): Promise<GetIdTokenResult> => {
+  try {
+    const serviceAccountEmail = state.serviceAccountEmail;
+    if (!serviceAccountEmail) {
+      return {
+        type: "error",
+        error: {
+          kind: "impersonation-failed",
+          message: "Service account email is required for impersonation",
+        },
+      };
+    }
+
+    logger.debug(
+      { serviceAccountEmail, audience },
+      "Fetching ID token via service account impersonation",
+    );
+
+    // ADCからアクセストークンを取得
+    const client = await state.googleAuth.getClient();
+    if (!client) {
+      return {
+        type: "error",
+        error: {
+          kind: "no-credentials",
+          message:
+            'No credentials found. Please run "gcloud auth application-default login" or set GOOGLE_APPLICATION_CREDENTIALS environment variable.',
+        },
+      };
+    }
+
+    const accessTokenResponse = await client.getAccessToken();
+    if (!accessTokenResponse.token) {
+      return {
+        type: "error",
+        error: {
+          kind: "impersonation-failed",
+          message: "Failed to get access token from ADC",
+        },
+      };
+    }
+
+    // IAM Credentials API を使用してIDトークンを生成
+    const url = `https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${serviceAccountEmail}:generateIdToken`;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessTokenResponse.token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        audience,
+        includeEmail: state.includeEmail,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      logger.error(
+        {
+          serviceAccountEmail,
+          status: response.status,
+          error: errorText,
+        },
+        "Failed to generate ID token via impersonation",
+      );
+      return {
+        type: "error",
+        error: {
+          kind: "impersonation-failed",
+          message: `Failed to generate ID token for service account ${serviceAccountEmail}: ${response.status} ${errorText}`,
+        },
+      };
+    }
+
+    const data = (await response.json()) as { token: string };
+    const idToken = data.token;
+
+    if (!idToken || typeof idToken !== "string") {
+      return {
+        type: "error",
+        error: {
+          kind: "invalid-token",
+          message: "Failed to retrieve a valid ID token from impersonation",
+        },
+      };
+    }
+
+    const expiresAt = extractTokenExpiration(idToken);
+
+    state.tokenCache[audience] = {
+      token: idToken,
+      expiresAt,
+    };
+
+    logger.debug(
+      { audience, expiresAt, serviceAccountEmail },
+      "Successfully fetched and cached impersonated ID token",
+    );
+
+    return {
+      type: "success",
+      token: idToken,
+      expiresAt,
+    };
+  } catch (error) {
+    logger.error(
+      {
+        serviceAccountEmail: state.serviceAccountEmail,
+        audience,
+        error: error instanceof Error ? error.message : "Unknown error",
+      },
+      "Failed to fetch ID token via impersonation",
+    );
+    return {
+      type: "error",
+      error: {
+        kind: "impersonation-failed",
+        message: `Failed to fetch ID token via impersonation: ${error instanceof Error ? error.message : "Unknown error"}`,
+      },
+    };
+  }
+};
+
 const fetchNewToken = async (
   state: GoogleAuthState,
   audience: string,
 ): Promise<GetIdTokenResult> => {
   try {
     logger.debug({ audience }, "Fetching new ID token from Google Auth");
+
+    // サービスアカウントインパーソネーションが指定されている場合
+    if (state.serviceAccountEmail && state.serviceAccountEmail.trim() !== "") {
+      logger.debug(
+        { serviceAccount: state.serviceAccountEmail },
+        "Using service account impersonation",
+      );
+      return await fetchTokenWithImpersonation(state, audience);
+    }
+
+    // 通常のADC処理
     const client = await state.googleAuth.getClient();
 
     if (!client) {
@@ -144,13 +293,15 @@ const getIdToken = async (
 ): Promise<GetIdTokenResult> => {
   logger.debug({ audience }, "Getting ID token");
 
-  if (!isValidAudience(audience)) {
+  if (!isValidAudience(audience, state.serviceAccountEmail)) {
     logger.warn({ audience }, "Invalid audience provided");
     return {
       type: "error",
       error: {
         kind: "invalid-audience",
-        message: `Invalid audience: ${audience}. Must be a valid HTTPS URL.`,
+        message: state.serviceAccountEmail
+          ? `Invalid audience: ${audience}. Must be a non-empty string.`
+          : `Invalid audience: ${audience}. Must be a valid HTTPS URL.`,
       },
     };
   }
@@ -184,7 +335,10 @@ const createGoogleAuthState = (config: AuthConfig = {}): GoogleAuthState => {
     keyFilename?: string;
     projectId?: string;
   } = {
-    scopes: [], // IDトークンには不要
+    // インパーソネーション時にはcloud-platformスコープが必要
+    scopes: config.serviceAccountEmail
+      ? ["https://www.googleapis.com/auth/cloud-platform"]
+      : [],
   };
 
   if (config.credentialsPath) {
@@ -198,6 +352,10 @@ const createGoogleAuthState = (config: AuthConfig = {}): GoogleAuthState => {
   return {
     googleAuth: new GoogleAuth(authOptions),
     tokenCache: {},
+    includeEmail: config.includeEmail ?? true,
+    ...(config.serviceAccountEmail && {
+      serviceAccountEmail: config.serviceAccountEmail,
+    }),
   };
 };
 

--- a/src/libs/auth/types.ts
+++ b/src/libs/auth/types.ts
@@ -11,7 +11,8 @@ type AuthError =
   | { kind: "no-credentials"; message: string }
   | { kind: "invalid-audience"; message: string }
   | { kind: "token-fetch-failed"; message: string }
-  | { kind: "invalid-token"; message: string };
+  | { kind: "invalid-token"; message: string }
+  | { kind: "impersonation-failed"; message: string };
 
 export type TokenCache = {
   [audience: string]: {
@@ -23,4 +24,6 @@ export type TokenCache = {
 export type AuthConfig = {
   credentialsPath?: string;
   projectId?: string;
+  serviceAccountEmail?: string;
+  includeEmail?: boolean;
 };

--- a/src/presentation/cli.ts
+++ b/src/presentation/cli.ts
@@ -20,6 +20,18 @@ const proxyCommand = define({
       default: 120000,
       description: "HTTP request timeout in milliseconds",
     },
+    "impersonate-service-account": {
+      type: "string",
+      description: "Service account email for impersonation (optional)",
+    },
+    audiences: {
+      type: "string",
+      description: "ID token audience (optional, defaults to target URL)",
+    },
+    "include-email": {
+      type: "boolean",
+      description: "Include email in ID token (default: true)",
+    },
   },
   examples: `# Basic usage (HTTPS)
 $ mcp-gcloud-adc-proxy --url https://my-service-abc123-uc.a.run.app
@@ -28,16 +40,39 @@ $ mcp-gcloud-adc-proxy --url https://my-service-abc123-uc.a.run.app
 $ mcp-gcloud-adc-proxy --url http://localhost:3000
 
 # With custom timeout
-$ mcp-gcloud-adc-proxy -u https://my-service-abc123-uc.a.run.app -t 60000`,
+$ mcp-gcloud-adc-proxy -u https://my-service-abc123-uc.a.run.app -t 60000
+
+# With service account impersonation
+$ mcp-gcloud-adc-proxy -u https://my-service-abc123-uc.a.run.app --impersonate-service-account sa@project.iam.gserviceaccount.com
+
+# With custom audience
+$ mcp-gcloud-adc-proxy -u https://my-service-abc123-uc.a.run.app --audiences https://example.com`,
   run: async (ctx) => {
-    const { url, timeout } = ctx.values;
-    await executeProxyCommand({ url, timeout });
+    const {
+      url,
+      timeout,
+      "impersonate-service-account": impersonateServiceAccount,
+      audiences,
+      "include-email": includeEmail,
+    } = ctx.values;
+    await executeProxyCommand({
+      url,
+      timeout,
+      ...(typeof impersonateServiceAccount === "string" && {
+        impersonateServiceAccount,
+      }),
+      ...(typeof audiences === "string" && { audiences }),
+      ...(typeof includeEmail === "boolean" && { includeEmail }),
+    });
   },
 });
 
 export type CliOptions = {
   url: string;
   timeout: number;
+  impersonateServiceAccount?: string;
+  audiences?: string;
+  includeEmail?: boolean;
 };
 
 export function validateCliOptions(options: CliOptions): void {
@@ -64,7 +99,13 @@ export function validateCliOptions(options: CliOptions): void {
 
 export async function executeProxyCommand(options: CliOptions): Promise<void> {
   logger.info(
-    { url: options.url, timeout: options.timeout },
+    {
+      url: options.url,
+      timeout: options.timeout,
+      impersonateServiceAccount: options.impersonateServiceAccount,
+      audiences: options.audiences,
+      includeEmail: options.includeEmail,
+    },
     "Executing proxy command",
   );
 
@@ -73,6 +114,13 @@ export async function executeProxyCommand(options: CliOptions): Promise<void> {
   const result = await startProxy({
     url: options.url,
     timeout: options.timeout,
+    ...(options.impersonateServiceAccount && {
+      impersonateServiceAccount: options.impersonateServiceAccount,
+    }),
+    ...(options.audiences && { audiences: options.audiences }),
+    ...(options.includeEmail !== undefined && {
+      includeEmail: options.includeEmail,
+    }),
   });
 
   if (result.type === "error") {

--- a/src/usecase/mcp-proxy/handler.ts
+++ b/src/usecase/mcp-proxy/handler.ts
@@ -37,7 +37,9 @@ const handleRequest = async (
       logger.debug({ sessionId }, "リクエストにセッションIDを追加");
     }
 
-    const tokenResult = await config.authClient.getIdToken(config.targetUrl);
+    // オーディエンス: 明示的に指定されていればそれを使用、なければターゲットURLを使用
+    const audience = config.audiences || config.targetUrl;
+    const tokenResult = await config.authClient.getIdToken(audience);
 
     if (tokenResult.type === "error") {
       logger.warn(
@@ -145,7 +147,9 @@ const handleMessage = async (
         logger.debug({ sessionId }, "通知にセッションIDを追加");
       }
 
-      const tokenResult = await config.authClient.getIdToken(config.targetUrl);
+      // オーディエンス: 明示的に指定されていればそれを使用、なければターゲットURLを使用
+      const audience = config.audiences || config.targetUrl;
+      const tokenResult = await config.authClient.getIdToken(audience);
 
       if (tokenResult.type === "error") {
         logger.warn(

--- a/src/usecase/mcp-proxy/types.ts
+++ b/src/usecase/mcp-proxy/types.ts
@@ -23,9 +23,13 @@ export type ProxyConfig = {
   authClient: AuthClient;
   httpClient: HttpClient;
   sessionManager: SessionManager;
+  audiences?: string;
 };
 
 export type ProxyOptions = {
   url: string;
   timeout: number;
+  impersonateServiceAccount?: string;
+  audiences?: string;
+  includeEmail?: boolean;
 };

--- a/src/usecase/start-proxy.ts
+++ b/src/usecase/start-proxy.ts
@@ -45,7 +45,14 @@ export async function startProxy(
   try {
     // 認証クライアントの初期化
     logger.debug("Initializing auth client");
-    const authClient = createAuthClient({});
+    const authClient = createAuthClient({
+      ...(options.impersonateServiceAccount && {
+        serviceAccountEmail: options.impersonateServiceAccount,
+      }),
+      ...(options.includeEmail !== undefined && {
+        includeEmail: options.includeEmail,
+      }),
+    });
 
     // HTTPクライアントの初期化
     logger.debug("Initializing HTTP client");
@@ -55,15 +62,19 @@ export async function startProxy(
     logger.debug("Initializing session manager");
     const sessionManager = createSessionManager();
 
-    // プロキシハンドラーの作成
-    logger.debug("Creating MCP proxy handler");
-    const proxy = createMcpProxy({
+    // プロキシ設定の作成
+    const proxyConfig = {
       targetUrl: options.url,
       timeout: options.timeout,
       authClient,
       httpClient,
       sessionManager,
-    });
+      ...(options.audiences && { audiences: options.audiences }),
+    };
+
+    // プロキシハンドラーの作成
+    logger.debug("Creating MCP proxy handler");
+    const proxy = createMcpProxy(proxyConfig);
 
     // MCPサーバーのセットアップと接続
     logger.info("Setting up MCP server");


### PR DESCRIPTION
Support Google Cloud service account impersonation. The options `--impersonate-service-account`, `--audiences` and `--include-email` are inspired by `gcloud auth print-identity-token`