### PR TITLE
Remove the 10-minute upper limit on --timeout

### DIFF
--- a/src/presentation/cli.test.ts
+++ b/src/presentation/cli.test.ts
@@ -74,13 +74,13 @@ describe("CLI", () => {
       ).toThrow("Timeout must be positive");
     });
 
-    it("大きすぎるタイムアウトを拒否する", () => {
+    it("大きなタイムアウトを許可する", () => {
       expect(() =>
         validateCliOptions({
           url: "https://example.com",
-          timeout: 700000,
+          timeout: 1800000,
         }),
-      ).toThrow("Timeout cannot exceed 10 minutes (600000ms)");
+      ).not.toThrow();
     });
   });
 

--- a/src/presentation/cli.ts
+++ b/src/presentation/cli.ts
@@ -91,10 +91,6 @@ export function validateCliOptions(options: CliOptions): void {
   if (timeout <= 0) {
     throw new Error("Timeout must be positive");
   }
-
-  if (timeout > 600000) {
-    throw new Error("Timeout cannot exceed 10 minutes (600000ms)");
-  }
 }
 
 export async function executeProxyCommand(options: CliOptions): Promise<void> {


### PR DESCRIPTION
Long running tools might exceed the hard limit.