### PR TITLE
feat: impersonation元ユーザーのIDトークンを X-Impersonator-Id-Token で上流へ送出

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,19 @@ npx mcp-gcloud-adc-proxy \
 - The ADC principal must have the `roles/iam.serviceAccountTokenCreator` role on the target service account
 - The target service account must have the necessary permissions to access the remote MCP server
 
+#### Forwarding the original user's identity
+
+When impersonation is enabled, the proxy also attaches an `X-Impersonator-Id-Token`
+header containing an ID token of the **original ADC user** (the human who ran the
+proxy), in addition to the impersonated service account token in `Authorization`.
+
+This lets a remote MCP server that authenticates via the service account still
+learn who the real caller is (e.g. to scope per-user permissions). The header is
+only attached when the ADC is a user credential (`gcloud auth application-default
+login`); it is omitted for service-account keys and other non-user credentials.
+If the original user's token cannot be obtained, the request still proceeds
+without the header.
+
 ### Custom Audience
 
 By default, the target URL is used as the audience for the ID token. You can override this with the `--audiences` option:

--- a/README.md
+++ b/README.md
@@ -55,13 +55,22 @@ npx mcp-gcloud-adc-proxy \
 
 #### Forwarding the original user's identity
 
-When impersonation is enabled, the proxy also attaches an `X-Impersonator-Id-Token`
-header containing an ID token of the **original ADC user** (the human who ran the
-proxy), in addition to the impersonated service account token in `Authorization`.
+When impersonation is enabled **and** `--forward-impersonator-token` is passed,
+the proxy also attaches an `X-Impersonator-Id-Token` header containing an ID token
+of the **original ADC user** (the human who ran the proxy), in addition to the
+impersonated service account token in `Authorization`.
+
+```bash
+npx mcp-gcloud-adc-proxy \
+  --url https://your-cloud-run-service.run.app \
+  --impersonate-service-account your-sa@your-project.iam.gserviceaccount.com \
+  --forward-impersonator-token
+```
 
 This lets a remote MCP server that authenticates via the service account still
-learn who the real caller is (e.g. to scope per-user permissions). The header is
-only attached when the ADC is a user credential (`gcloud auth application-default
+learn who the real caller is (e.g. to scope per-user permissions). It is **off by
+default**; without the flag, only the service account token is sent. The header is
+attached only when the ADC is a user credential (`gcloud auth application-default
 login`); it is omitted for service-account keys and other non-user credentials.
 If the original user's token cannot be obtained, the request still proceeds
 without the header.

--- a/src/libs/auth/google-auth.test.ts
+++ b/src/libs/auth/google-auth.test.ts
@@ -227,6 +227,26 @@ describe("createAuthClient", () => {
     expect(typeof client.getIdToken).toBe("function");
     expect(typeof client.refreshToken).toBe("function");
   });
+
+  it("インパーソネーション+送出フラグ有効時に getImpersonatorIdToken を生やす", () => {
+    const client = createAuthClient({
+      serviceAccountEmail: "test-sa@project.iam.gserviceaccount.com",
+      emitImpersonatorToken: true,
+    });
+    expect(typeof client.getImpersonatorIdToken).toBe("function");
+  });
+
+  it("送出フラグ無効時は getImpersonatorIdToken を生やさない", () => {
+    const client = createAuthClient({
+      serviceAccountEmail: "test-sa@project.iam.gserviceaccount.com",
+    });
+    expect(client.getImpersonatorIdToken).toBeUndefined();
+  });
+
+  it("インパーソネーション未指定なら送出フラグがあっても生やさない", () => {
+    const client = createAuthClient({ emitImpersonatorToken: true });
+    expect(client.getImpersonatorIdToken).toBeUndefined();
+  });
 });
 
 describe.skip("サービスアカウントインパーソネーション", () => {

--- a/src/libs/auth/google-auth.ts
+++ b/src/libs/auth/google-auth.ts
@@ -12,7 +12,15 @@ type GoogleAuthState = {
   tokenCache: TokenCache;
   serviceAccountEmail?: string;
   includeEmail: boolean;
+  emitImpersonatorToken: boolean;
+  // インパーソネーション元トークンは aud 固定のため単一エントリでキャッシュする。
+  // Authorization 用の tokenCache とはキー空間を分離する。
+  impersonatorTokenCache: TokenCache;
 };
+
+// インパーソネーション元トークンのキャッシュキー（aud は固定だが、形式を
+// tokenCache に揃えるための内部キー）。
+const IMPERSONATOR_CACHE_KEY = "impersonator";
 
 const isValidAudience = (
   audience: string,
@@ -287,6 +295,100 @@ const fetchNewToken = async (
   }
 };
 
+// インパーソネーションを「挟まない」素のADCクライアント（gcloudユーザー）から
+// refresh_token グラントでIDトークンを取得する。target_audience を指定しない
+// ため `gcloud auth print-identity-token` 相当となり、email クレームを含み
+// aud は gcloud の client id になる。
+const fetchImpersonatorIdToken = async (
+  state: GoogleAuthState,
+): Promise<GetIdTokenResult> => {
+  try {
+    const client = await state.googleAuth.getClient();
+    if (!client) {
+      return {
+        type: "error",
+        error: {
+          kind: "no-credentials",
+          message:
+            'No credentials found. Please run "gcloud auth application-default login".',
+        },
+      };
+    }
+
+    // refresh_token グラントで素のIDトークンを返せるのは UserRefreshClient のみ。
+    // SAキーやCompute等の非ユーザー資格情報では impersonator トークンを出さない。
+    if (!("refreshTokenNoCache" in client)) {
+      return {
+        type: "error",
+        error: {
+          kind: "no-credentials",
+          message:
+            "ADC is not a user credential; cannot emit an impersonator ID token.",
+        },
+      };
+    }
+
+    // refreshTokenNoCache は UserRefreshClient 上では型定義上 protected だが、
+    // 実行時は public（refreshclient.js）。unknown 経由でキャストして呼ぶ。
+    const { tokens } = await (
+      client as unknown as {
+        refreshTokenNoCache: () => Promise<{ tokens: { id_token?: string } }>;
+      }
+    ).refreshTokenNoCache();
+    const idToken = tokens.id_token;
+
+    if (!idToken || typeof idToken !== "string") {
+      return {
+        type: "error",
+        error: {
+          kind: "invalid-token",
+          message: "Refresh response did not include an id_token.",
+        },
+      };
+    }
+
+    const expiresAt = extractTokenExpiration(idToken);
+    state.impersonatorTokenCache[IMPERSONATOR_CACHE_KEY] = {
+      token: idToken,
+      expiresAt,
+    };
+
+    logger.debug(
+      { expiresAt },
+      "Successfully fetched and cached impersonator ID token",
+    );
+
+    return { type: "success", token: idToken, expiresAt };
+  } catch (error) {
+    logger.error(
+      { error: error instanceof Error ? error.message : "Unknown error" },
+      "Failed to fetch impersonator ID token",
+    );
+    return {
+      type: "error",
+      error: {
+        kind: "token-fetch-failed",
+        message: `Failed to fetch impersonator ID token: ${error instanceof Error ? error.message : "Unknown error"}`,
+      },
+    };
+  }
+};
+
+const getImpersonatorIdToken = async (
+  state: GoogleAuthState,
+): Promise<GetIdTokenResult> => {
+  const cached = state.impersonatorTokenCache[IMPERSONATOR_CACHE_KEY];
+  if (cached && isTokenValid(cached.expiresAt)) {
+    logger.debug("Using cached impersonator token");
+    return {
+      type: "success",
+      token: cached.token,
+      expiresAt: cached.expiresAt,
+    };
+  }
+  return fetchImpersonatorIdToken(state);
+};
+
 const getIdToken = async (
   state: GoogleAuthState,
   audience: string,
@@ -352,7 +454,9 @@ const createGoogleAuthState = (config: AuthConfig = {}): GoogleAuthState => {
   return {
     googleAuth: new GoogleAuth(authOptions),
     tokenCache: {},
+    impersonatorTokenCache: {},
     includeEmail: config.includeEmail ?? true,
+    emitImpersonatorToken: config.emitImpersonatorToken ?? false,
     ...(config.serviceAccountEmail && {
       serviceAccountEmail: config.serviceAccountEmail,
     }),
@@ -366,5 +470,9 @@ export function createAuthClient(config: AuthConfig = {}): AuthClient {
   return {
     getIdToken: (audience: string) => getIdToken(state, audience),
     refreshToken: (audience: string) => refreshToken(state, audience),
+    // インパーソネーション有効かつ送出フラグが立っているときのみ生やす。
+    ...(state.emitImpersonatorToken && state.serviceAccountEmail
+      ? { getImpersonatorIdToken: () => getImpersonatorIdToken(state) }
+      : {}),
   };
 }

--- a/src/libs/auth/types.ts
+++ b/src/libs/auth/types.ts
@@ -1,6 +1,9 @@
 export type AuthClient = {
   getIdToken: (audience: string) => Promise<GetIdTokenResult>;
   refreshToken: (audience: string) => Promise<GetIdTokenResult>;
+  // インパーソネーション有効時のみ生える。インパーソネーション元（実ユーザー）の
+  // 素のIDトークン（gcloud client id を aud に持ち email を含む）を返す。
+  getImpersonatorIdToken?: () => Promise<GetIdTokenResult>;
 };
 
 export type GetIdTokenResult =
@@ -26,4 +29,7 @@ export type AuthConfig = {
   projectId?: string;
   serviceAccountEmail?: string;
   includeEmail?: boolean;
+  // インパーソネーション元の実ユーザーのIDトークンを X-Impersonator-Id-Token
+  // ヘッダーで上流へ送るかどうか。
+  emitImpersonatorToken?: boolean;
 };

--- a/src/presentation/cli.ts
+++ b/src/presentation/cli.ts
@@ -32,6 +32,11 @@ const proxyCommand = define({
       type: "boolean",
       description: "Include email in ID token (default: true)",
     },
+    "forward-impersonator-token": {
+      type: "boolean",
+      description:
+        "When impersonating, also forward the original ADC user's ID token in the X-Impersonator-Id-Token header (default: false)",
+    },
   },
   examples: `# Basic usage (HTTPS)
 $ mcp-gcloud-adc-proxy --url https://my-service-abc123-uc.a.run.app
@@ -46,7 +51,10 @@ $ mcp-gcloud-adc-proxy -u https://my-service-abc123-uc.a.run.app -t 60000
 $ mcp-gcloud-adc-proxy -u https://my-service-abc123-uc.a.run.app --impersonate-service-account sa@project.iam.gserviceaccount.com
 
 # With custom audience
-$ mcp-gcloud-adc-proxy -u https://my-service-abc123-uc.a.run.app --audiences https://example.com`,
+$ mcp-gcloud-adc-proxy -u https://my-service-abc123-uc.a.run.app --audiences https://example.com
+
+# Impersonate and also forward the original user's ID token
+$ mcp-gcloud-adc-proxy -u https://my-service-abc123-uc.a.run.app --impersonate-service-account sa@project.iam.gserviceaccount.com --forward-impersonator-token`,
   run: async (ctx) => {
     const {
       url,
@@ -54,6 +62,7 @@ $ mcp-gcloud-adc-proxy -u https://my-service-abc123-uc.a.run.app --audiences htt
       "impersonate-service-account": impersonateServiceAccount,
       audiences,
       "include-email": includeEmail,
+      "forward-impersonator-token": forwardImpersonatorToken,
     } = ctx.values;
     await executeProxyCommand({
       url,
@@ -63,6 +72,9 @@ $ mcp-gcloud-adc-proxy -u https://my-service-abc123-uc.a.run.app --audiences htt
       }),
       ...(typeof audiences === "string" && { audiences }),
       ...(typeof includeEmail === "boolean" && { includeEmail }),
+      ...(typeof forwardImpersonatorToken === "boolean" && {
+        forwardImpersonatorToken,
+      }),
     });
   },
 });
@@ -73,6 +85,7 @@ export type CliOptions = {
   impersonateServiceAccount?: string;
   audiences?: string;
   includeEmail?: boolean;
+  forwardImpersonatorToken?: boolean;
 };
 
 export function validateCliOptions(options: CliOptions): void {
@@ -101,6 +114,7 @@ export async function executeProxyCommand(options: CliOptions): Promise<void> {
       impersonateServiceAccount: options.impersonateServiceAccount,
       audiences: options.audiences,
       includeEmail: options.includeEmail,
+      forwardImpersonatorToken: options.forwardImpersonatorToken,
     },
     "Executing proxy command",
   );
@@ -116,6 +130,9 @@ export async function executeProxyCommand(options: CliOptions): Promise<void> {
     ...(options.audiences && { audiences: options.audiences }),
     ...(options.includeEmail !== undefined && {
       includeEmail: options.includeEmail,
+    }),
+    ...(options.forwardImpersonatorToken !== undefined && {
+      forwardImpersonatorToken: options.forwardImpersonatorToken,
     }),
   });
 

--- a/src/usecase/mcp-proxy/handler.test.ts
+++ b/src/usecase/mcp-proxy/handler.test.ts
@@ -369,6 +369,80 @@ describe("McpProxy", () => {
       });
     });
   });
+
+  describe("X-Impersonator-Id-Token ヘッダー", () => {
+    const request: JSONRPCRequest = {
+      jsonrpc: "2.0" as const,
+      id: 1,
+      method: "tools/list",
+      params: {},
+    };
+    const okResponse: JSONRPCResponse = {
+      jsonrpc: "2.0" as const,
+      id: 1,
+      result: { tools: [] },
+    };
+
+    beforeEach(() => {
+      (mockSessionManager.getSessionId as Mock).mockReturnValue(null);
+      (mockAuthClient.getIdToken as Mock).mockResolvedValue({
+        type: "success",
+        token: "mock-token",
+        expiresAt: new Date(Date.now() + 3600000),
+      });
+      (mockHttpClient.post as Mock).mockResolvedValue({
+        type: "success",
+        data: okResponse,
+        status: 200,
+        headers: {},
+      });
+    });
+
+    it("getImpersonatorIdToken 成功時にヘッダーを付与する", async () => {
+      mockAuthClient.getImpersonatorIdToken = vi.fn().mockResolvedValue({
+        type: "success",
+        token: "impersonator-token",
+        expiresAt: new Date(Date.now() + 3600000),
+      }) as Mock;
+      const p = createMcpProxy(config);
+
+      await p.handleRequest(request);
+
+      const postArg = (mockHttpClient.post as Mock).mock.calls[0]?.[0] as {
+        headers: Record<string, string>;
+      };
+      expect(postArg.headers["X-Impersonator-Id-Token"]).toBe(
+        "impersonator-token",
+      );
+    });
+
+    it("getImpersonatorIdToken 失敗時はヘッダーを付与せず続行する", async () => {
+      mockAuthClient.getImpersonatorIdToken = vi.fn().mockResolvedValue({
+        type: "error",
+        error: { kind: "no-credentials", message: "no user credential" },
+      }) as Mock;
+      const p = createMcpProxy(config);
+
+      const result = await p.handleRequest(request);
+
+      const postArg = (mockHttpClient.post as Mock).mock.calls[0]?.[0] as {
+        headers: Record<string, string>;
+      };
+      expect("X-Impersonator-Id-Token" in postArg.headers).toBe(false);
+      expect(result).toEqual(okResponse);
+    });
+
+    it("getImpersonatorIdToken 未定義時はヘッダーを付与しない", async () => {
+      const p = createMcpProxy(config);
+
+      await p.handleRequest(request);
+
+      const postArg = (mockHttpClient.post as Mock).mock.calls[0]?.[0] as {
+        headers: Record<string, string>;
+      };
+      expect("X-Impersonator-Id-Token" in postArg.headers).toBe(false);
+    });
+  });
 });
 
 describe("createMcpProxy", () => {

--- a/src/usecase/mcp-proxy/handler.ts
+++ b/src/usecase/mcp-proxy/handler.ts
@@ -15,6 +15,27 @@ import {
 } from "../../presentation/mcp-proxy-handlers.js";
 import type { McpProxy, ProxyConfig } from "./types.js";
 
+// インパーソネーション元（実ユーザー）のIDトークンを X-Impersonator-Id-Token
+// ヘッダーに付与する。取得失敗時はヘッダーを付けずに続行する（上流が SA 単独で
+// fail-closed に倒れるだけ）。authClient がこのメソッドを持たない場合は何もしない。
+const attachImpersonatorHeader = async (
+  config: ProxyConfig,
+  headers: Record<string, string>,
+): Promise<void> => {
+  if (!config.authClient.getImpersonatorIdToken) {
+    return;
+  }
+  const result = await config.authClient.getImpersonatorIdToken();
+  if (result.type === "success") {
+    headers["X-Impersonator-Id-Token"] = result.token;
+  } else {
+    logger.warn(
+      { error: result.error },
+      "Impersonator ID token unavailable; continuing without it",
+    );
+  }
+};
+
 const handleRequest = async (
   config: ProxyConfig,
   request: JSONRPCRequest,
@@ -54,6 +75,7 @@ const handleRequest = async (
     }
 
     headers.Authorization = `Bearer ${tokenResult.token}`;
+    await attachImpersonatorHeader(config, headers);
 
     const httpResponse = await config.httpClient.post({
       url: config.targetUrl,
@@ -160,6 +182,7 @@ const handleMessage = async (
       }
 
       headers.Authorization = `Bearer ${tokenResult.token}`;
+      await attachImpersonatorHeader(config, headers);
 
       const httpResponse = await config.httpClient.post({
         url: config.targetUrl,

--- a/src/usecase/mcp-proxy/types.ts
+++ b/src/usecase/mcp-proxy/types.ts
@@ -32,4 +32,5 @@ export type ProxyOptions = {
   impersonateServiceAccount?: string;
   audiences?: string;
   includeEmail?: boolean;
+  forwardImpersonatorToken?: boolean;
 };

--- a/src/usecase/start-proxy.ts
+++ b/src/usecase/start-proxy.ts
@@ -52,6 +52,8 @@ export async function startProxy(
       ...(options.includeEmail !== undefined && {
         includeEmail: options.includeEmail,
       }),
+      // インパーソネーション時は元ユーザーのIDトークンを上流へ送出する。
+      emitImpersonatorToken: Boolean(options.impersonateServiceAccount),
     });
 
     // HTTPクライアントの初期化

--- a/src/usecase/start-proxy.ts
+++ b/src/usecase/start-proxy.ts
@@ -52,8 +52,11 @@ export async function startProxy(
       ...(options.includeEmail !== undefined && {
         includeEmail: options.includeEmail,
       }),
-      // インパーソネーション時は元ユーザーのIDトークンを上流へ送出する。
-      emitImpersonatorToken: Boolean(options.impersonateServiceAccount),
+      // --forward-impersonator-token 指定かつインパーソネーション時のみ、
+      // 元ユーザーのIDトークンを X-Impersonator-Id-Token で上流へ送出する。
+      emitImpersonatorToken: Boolean(
+        options.impersonateServiceAccount && options.forwardImpersonatorToken,
+      ),
     });
 
     // HTTPクライアントの初期化


### PR DESCRIPTION
## 背景

このプロキシは `--impersonate-service-account` 指定時、IAM Credentials API の `generateIdToken` で **サービスアカウント(SA)の ID トークン**を発行し `Authorization` ヘッダーに載せて上流の MCP サーバーへ転送する。このため上流には SA しか伝わらず、**元の人間ユーザー(プロキシを実行した本人)が誰か分からない**。

上流が「呼び出した人間」に応じて権限制御したいケースで、この情報欠落が問題になる。

## 変更内容

`--forward-impersonator-token` フラグ(**デフォルト false**)を追加し、**このフラグ指定時かつインパーソネーション有効時のみ**、元ユーザーの ID トークンを `X-Impersonator-Id-Token` ヘッダーに載せて上流へ送る。

```bash
mcp-gcloud-adc-proxy \
  --url https://your-cloud-run-service.run.app \
  --impersonate-service-account sa@project.iam.gserviceaccount.com \
  --forward-impersonator-token
```

送出されるトークンについて:
- インパーソネーションを「挟まない」素の ADC(gcloud ユーザー)から `UserRefreshClient.refreshTokenNoCache()` で取得する。`target_audience` を指定しないため `gcloud auth print-identity-token` 相当となり、**email クレームを含み、aud は gcloud ADC(application-default)の OAuth クライアント ID**(`764086051850-...apps.googleusercontent.com`)になる。
  - 補足: `fetchIdToken(targetAudience)` は aud を任意にできるが **email クレームが乗らない**ため、email を必要とする上流では使えない。よって素の id_token を採用。
- ADC がユーザー資格情報でない(SA キー / Compute 等で `refreshTokenNoCache` を持たない)場合はヘッダーを付けない。
- トークン取得に失敗してもリクエストは継続(fail-open。上流は SA 単独で動くだけ)。
- このトークンは aud 固定のため Authorization 用とは別の専用キャッシュに保持。

### 送出条件まとめ

| 条件 | `X-Impersonator-Id-Token` |
|---|---|
| インパーソネーションなし | 送らない |
| インパーソネーションあり + フラグなし | 送らない(デフォルト) |
| インパーソネーションあり + `--forward-impersonator-token` | 送る |
