### PR TITLE
fix: 上流のJSON-RPCエラーレスポンスを空のresultに変換せずMcpErrorとして伝播する

### DIFF
--- a/src/presentation/mcp-server-handlers.test.ts
+++ b/src/presentation/mcp-server-handlers.test.ts
@@ -1,0 +1,112 @@
+import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import type {
+  JSONRPCMessage,
+  JSONRPCResponse,
+} from "@modelcontextprotocol/sdk/types.js";
+import { McpError } from "@modelcontextprotocol/sdk/types.js";
+import { describe, expect, it } from "vitest";
+import type { McpProxy } from "../usecase/mcp-proxy/types.js";
+import { registerProxyHandlers } from "./mcp-server-handlers.js";
+
+type RequestHandler = (
+  request: { method: string; params?: unknown },
+  extra: unknown,
+) => Promise<unknown>;
+
+const buildServerStub = () => {
+  let initializeHandler: RequestHandler | undefined;
+  const server = {
+    setRequestHandler: (_schema: unknown, handler: RequestHandler) => {
+      initializeHandler = handler;
+    },
+    fallbackRequestHandler: undefined as RequestHandler | undefined,
+  };
+  return {
+    server: server as unknown as Server,
+    getInitializeHandler: () => initializeHandler,
+    getFallbackHandler: () => server.fallbackRequestHandler,
+  };
+};
+
+const buildProxyStub = (response: JSONRPCResponse): McpProxy => ({
+  handleRequest: async () => response,
+  handleMessage: async (message: JSONRPCMessage) => message,
+});
+
+const successResponse = {
+  jsonrpc: "2.0",
+  id: "proxy-1",
+  result: { content: [{ type: "text", text: "調査結果" }] },
+} as JSONRPCResponse;
+
+const errorResponse = {
+  jsonrpc: "2.0",
+  id: "proxy-1",
+  error: {
+    code: -32603,
+    message: "Invalid response format from target server",
+  },
+} as unknown as JSONRPCResponse;
+
+describe("registerProxyHandlers", () => {
+  describe("fallbackRequestHandler", () => {
+    it("成功レスポンスのresultをそのまま返す", async () => {
+      const { server, getFallbackHandler } = buildServerStub();
+      registerProxyHandlers(server, {
+        proxy: buildProxyStub(successResponse),
+        idGenerator: () => "proxy-1",
+      });
+
+      const handler = getFallbackHandler();
+      const result = await handler?.({ method: "tools/call" }, {});
+
+      expect(result).toEqual({ content: [{ type: "text", text: "調査結果" }] });
+    });
+
+    it("エラーレスポンスを空のresultに変換せずMcpErrorとして伝播する", async () => {
+      const { server, getFallbackHandler } = buildServerStub();
+      registerProxyHandlers(server, {
+        proxy: buildProxyStub(errorResponse),
+        idGenerator: () => "proxy-1",
+      });
+
+      const handler = getFallbackHandler();
+
+      await expect(handler?.({ method: "tools/call" }, {})).rejects.toThrow(
+        McpError,
+      );
+      await expect(handler?.({ method: "tools/call" }, {})).rejects.toThrow(
+        /Invalid response format from target server/,
+      );
+    });
+  });
+
+  describe("initializeハンドラ", () => {
+    it("成功レスポンスのresultをそのまま返す", async () => {
+      const { server, getInitializeHandler } = buildServerStub();
+      registerProxyHandlers(server, {
+        proxy: buildProxyStub(successResponse),
+        idGenerator: () => "proxy-1",
+      });
+
+      const handler = getInitializeHandler();
+      const result = await handler?.({ method: "initialize", params: {} }, {});
+
+      expect(result).toEqual({ content: [{ type: "text", text: "調査結果" }] });
+    });
+
+    it("エラーレスポンスをMcpErrorとして伝播する", async () => {
+      const { server, getInitializeHandler } = buildServerStub();
+      registerProxyHandlers(server, {
+        proxy: buildProxyStub(errorResponse),
+        idGenerator: () => "proxy-1",
+      });
+
+      const handler = getInitializeHandler();
+
+      await expect(
+        handler?.({ method: "initialize", params: {} }, {}),
+      ).rejects.toThrow(McpError);
+    });
+  });
+});

--- a/src/presentation/mcp-server-handlers.ts
+++ b/src/presentation/mcp-server-handlers.ts
@@ -1,6 +1,10 @@
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import type { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { InitializeRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import type { JSONRPCResponse } from "@modelcontextprotocol/sdk/types.js";
+import {
+  InitializeRequestSchema,
+  McpError,
+} from "@modelcontextprotocol/sdk/types.js";
 import type { McpProxy } from "../usecase/mcp-proxy/types.js";
 
 type IdGeneratorFn = () => string | number;
@@ -8,6 +12,26 @@ type IdGeneratorFn = () => string | number;
 type HandlerConfig = {
   proxy: McpProxy;
   idGenerator: IdGeneratorFn;
+};
+
+// SDKのリクエストハンドラはthrowされたMcpErrorをJSON-RPCエラーレスポンスとして
+// クライアントに返す仕様のため、ここでは tagged union ではなく throw で伝播する。
+const unwrapProxyResponse = (
+  proxyResponse: JSONRPCResponse,
+): Record<string, unknown> => {
+  const errorField = (
+    proxyResponse as unknown as {
+      error?: { code?: number; message?: string; data?: unknown };
+    }
+  ).error;
+  if (errorField) {
+    throw new McpError(
+      errorField.code ?? -32603,
+      errorField.message ?? "Unknown upstream error",
+      errorField.data,
+    );
+  }
+  return (proxyResponse.result as Record<string, unknown> | undefined) || {};
 };
 
 export function registerProxyHandlers(
@@ -23,7 +47,7 @@ export function registerProxyHandlers(
       method: "initialize",
       params: request.params,
     });
-    return proxyResponse.result || {};
+    return unwrapProxyResponse(proxyResponse);
   });
 
   server.fallbackRequestHandler = async (request, _) => {
@@ -33,7 +57,7 @@ export function registerProxyHandlers(
       method: request.method,
       params: request.params,
     });
-    return proxyResponse.result || {};
+    return unwrapProxyResponse(proxyResponse);
   };
 }
 


### PR DESCRIPTION
プロキシ内部でエラーレスポンス(タイムアウト・上流5xx・パース失敗等)が生成されても、
ハンドラの `proxyResponse.result || {}` が握りつぶして「エラーなし・中身空」の成功 としてクライアントに返していた。エラーフィールドを検出した場合はMcpErrorをthrowし、
SDK経由でJSON-RPCエラーとしてクライアントに届くようにする。