### PR TITLE
fix(http): pick JSON-RPC response from SSE & fix error response

### DIFF
--- a/src/libs/http/http-client.ts
+++ b/src/libs/http/http-client.ts
@@ -63,12 +63,33 @@ const post = async (config: HttpRequestConfig): Promise<HttpResponse> => {
     let data: unknown;
 
     try {
-      // SSE形式のレスポンスをチェック（MCP over HTTP）
-      if (responseText.includes("event: message\ndata: ")) {
-        const dataMatch = responseText.match(/data: (.+)/);
-        if (dataMatch?.[1]) {
-          data = JSON.parse(dataMatch[1]);
-        } else {
+      // SSE形式のレスポンス(MCP over HTTP)は "data:" で始まる行を持つ。
+      // 本文中に文字列 "data:" を含む通常のJSONを誤検出しないよう、行頭で判定する。
+      const dataLines = responseText
+        .split("\n")
+        .filter((line) => line.startsWith("data:"));
+      if (dataLines.length > 0) {
+        // ストリームには進捗通知(notifications/progress)等がレスポンスより前に
+        // 含まれうる。全 data: 行を見て JSON-RPC レスポンス(idを持つ)を優先返却。
+        // 無ければ最後の有効なJSONを返す。
+        const messages = dataLines
+          .map((line) => line.slice("data:".length).trim())
+          .filter(Boolean)
+          .flatMap((payload) => {
+            try {
+              return [JSON.parse(payload)];
+            } catch {
+              return [];
+            }
+          });
+        const jsonRpcResponse = [...messages]
+          .reverse()
+          .find(
+            (m): m is Record<string, unknown> =>
+              typeof m === "object" && m !== null && "id" in m,
+          );
+        data = jsonRpcResponse ?? messages[messages.length - 1];
+        if (data === undefined) {
           return {
             type: "error",
             error: {

--- a/src/presentation/mcp-server-handlers.test.ts
+++ b/src/presentation/mcp-server-handlers.test.ts
@@ -1,0 +1,112 @@
+import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import type {
+  JSONRPCMessage,
+  JSONRPCResponse,
+} from "@modelcontextprotocol/sdk/types.js";
+import { McpError } from "@modelcontextprotocol/sdk/types.js";
+import { describe, expect, it } from "vitest";
+import type { McpProxy } from "../usecase/mcp-proxy/types.js";
+import { registerProxyHandlers } from "./mcp-server-handlers.js";
+
+type RequestHandler = (
+  request: { method: string; params?: unknown },
+  extra: unknown,
+) => Promise<unknown>;
+
+const buildServerStub = () => {
+  let initializeHandler: RequestHandler | undefined;
+  const server = {
+    setRequestHandler: (_schema: unknown, handler: RequestHandler) => {
+      initializeHandler = handler;
+    },
+    fallbackRequestHandler: undefined as RequestHandler | undefined,
+  };
+  return {
+    server: server as unknown as Server,
+    getInitializeHandler: () => initializeHandler,
+    getFallbackHandler: () => server.fallbackRequestHandler,
+  };
+};
+
+const buildProxyStub = (response: JSONRPCResponse): McpProxy => ({
+  handleRequest: async () => response,
+  handleMessage: async (message: JSONRPCMessage) => message,
+});
+
+const successResponse = {
+  jsonrpc: "2.0",
+  id: "proxy-1",
+  result: { content: [{ type: "text", text: "調査結果" }] },
+} as JSONRPCResponse;
+
+const errorResponse = {
+  jsonrpc: "2.0",
+  id: "proxy-1",
+  error: {
+    code: -32603,
+    message: "Invalid response format from target server",
+  },
+} as unknown as JSONRPCResponse;
+
+describe("registerProxyHandlers", () => {
+  describe("fallbackRequestHandler", () => {
+    it("成功レスポンスのresultをそのまま返す", async () => {
+      const { server, getFallbackHandler } = buildServerStub();
+      registerProxyHandlers(server, {
+        proxy: buildProxyStub(successResponse),
+        idGenerator: () => "proxy-1",
+      });
+
+      const handler = getFallbackHandler();
+      const result = await handler?.({ method: "tools/call" }, {});
+
+      expect(result).toEqual({ content: [{ type: "text", text: "調査結果" }] });
+    });
+
+    it("エラーレスポンスを空のresultに変換せずMcpErrorとして伝播する", async () => {
+      const { server, getFallbackHandler } = buildServerStub();
+      registerProxyHandlers(server, {
+        proxy: buildProxyStub(errorResponse),
+        idGenerator: () => "proxy-1",
+      });
+
+      const handler = getFallbackHandler();
+
+      await expect(handler?.({ method: "tools/call" }, {})).rejects.toThrow(
+        McpError,
+      );
+      await expect(handler?.({ method: "tools/call" }, {})).rejects.toThrow(
+        /Invalid response format from target server/,
+      );
+    });
+  });
+
+  describe("initializeハンドラ", () => {
+    it("成功レスポンスのresultをそのまま返す", async () => {
+      const { server, getInitializeHandler } = buildServerStub();
+      registerProxyHandlers(server, {
+        proxy: buildProxyStub(successResponse),
+        idGenerator: () => "proxy-1",
+      });
+
+      const handler = getInitializeHandler();
+      const result = await handler?.({ method: "initialize", params: {} }, {});
+
+      expect(result).toEqual({ content: [{ type: "text", text: "調査結果" }] });
+    });
+
+    it("エラーレスポンスをMcpErrorとして伝播する", async () => {
+      const { server, getInitializeHandler } = buildServerStub();
+      registerProxyHandlers(server, {
+        proxy: buildProxyStub(errorResponse),
+        idGenerator: () => "proxy-1",
+      });
+
+      const handler = getInitializeHandler();
+
+      await expect(
+        handler?.({ method: "initialize", params: {} }, {}),
+      ).rejects.toThrow(McpError);
+    });
+  });
+});

--- a/src/presentation/mcp-server-handlers.ts
+++ b/src/presentation/mcp-server-handlers.ts
@@ -1,6 +1,10 @@
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import type { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { InitializeRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import type { JSONRPCResponse } from "@modelcontextprotocol/sdk/types.js";
+import {
+  InitializeRequestSchema,
+  McpError,
+} from "@modelcontextprotocol/sdk/types.js";
 import type { McpProxy } from "../usecase/mcp-proxy/types.js";
 
 type IdGeneratorFn = () => string | number;
@@ -8,6 +12,26 @@ type IdGeneratorFn = () => string | number;
 type HandlerConfig = {
   proxy: McpProxy;
   idGenerator: IdGeneratorFn;
+};
+
+// SDKのリクエストハンドラはthrowされたMcpErrorをJSON-RPCエラーレスポンスとして
+// クライアントに返す仕様のため、ここでは tagged union ではなく throw で伝播する。
+const unwrapProxyResponse = (
+  proxyResponse: JSONRPCResponse,
+): Record<string, unknown> => {
+  const errorField = (
+    proxyResponse as unknown as {
+      error?: { code?: number; message?: string; data?: unknown };
+    }
+  ).error;
+  if (errorField) {
+    throw new McpError(
+      errorField.code ?? -32603,
+      errorField.message ?? "Unknown upstream error",
+      errorField.data,
+    );
+  }
+  return (proxyResponse.result as Record<string, unknown> | undefined) || {};
 };
 
 export function registerProxyHandlers(
@@ -23,7 +47,7 @@ export function registerProxyHandlers(
       method: "initialize",
       params: request.params,
     });
-    return proxyResponse.result || {};
+    return unwrapProxyResponse(proxyResponse);
   });
 
   server.fallbackRequestHandler = async (request, _) => {
@@ -33,7 +57,7 @@ export function registerProxyHandlers(
       method: request.method,
       params: request.params,
     });
-    return proxyResponse.result || {};
+    return unwrapProxyResponse(proxyResponse);
   };
 }
 


### PR DESCRIPTION
SSE パーサが最初の data: イベントだけを採用していたため、上流 MCP サーバが結果より前に進捗通知(notifications/progress)を流すと、最初のイベント=通知(idなし)を拾って validateJSONRPCResponse が失敗し、呼び出し元に空/無効レスポンスが返っていた。全 data: 行を見て id を持つ JSON-RPC レスポンスを返すよう修正。SSE 判定も行頭一致にして通常JSONの誤検出を回避。

またエラーレスポンスがSDK経由でJSON-RPCエラーとしてクライアントに届くようにする。