### PR TITLE
リダイレクトを追わずにエラーとして返す

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ login`); it is omitted for service-account keys and other non-user credentials.
 If the original user's token cannot be obtained, the request still proceeds
 without the header.
 
+Redirects are **not** followed. `Authorization` is dropped by the runtime on a
+cross-origin redirect, but custom headers such as `X-Impersonator-Id-Token` are
+not, so following a redirect would hand the caller's ID token to another origin.
+A redirect response is returned to the caller as an HTTP error instead.
+
 ### Custom Audience
 
 By default, the target URL is used as the audience for the ID token. You can override this with the `--audiences` option:

--- a/src/libs/http/http-client.test.ts
+++ b/src/libs/http/http-client.test.ts
@@ -60,6 +60,7 @@ describe("HttpClient", () => {
         },
         body: '{"test":"data"}',
         signal: mockAbortController.signal,
+        redirect: "manual",
       });
 
       expect(result.type).toBe("success");
@@ -312,6 +313,84 @@ describe("HttpClient", () => {
           message: "Request timed out after 1000ms",
         },
       });
+    });
+  });
+});
+
+describe("リダイレクト", () => {
+  let httpClient: ReturnType<typeof createHttpClient>;
+
+  beforeEach(() => {
+    httpClient = createHttpClient();
+    vi.clearAllMocks();
+    global.AbortController = vi.fn().mockImplementation(() => ({
+      abort: vi.fn(),
+      signal: { aborted: false },
+    }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const config: HttpRequestConfig = {
+    url: "https://example.com/api",
+    headers: { "x-impersonator-id-token": "dummy-token" },
+    body: {},
+    timeout: 5000,
+  };
+
+  const redirectResponse = {
+    ok: false,
+    status: 302,
+    statusText: "Found",
+    headers: new Map([["location", "https://example.com/login"]]),
+    text: vi.fn().mockResolvedValue(""),
+  };
+
+  it("postはリダイレクトを追わない", async () => {
+    mockFetch.mockResolvedValue(redirectResponse);
+
+    const result = await httpClient.post(config);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://example.com/api",
+      expect.objectContaining({ redirect: "manual" }),
+    );
+    expect(result).toMatchObject({
+      type: "error",
+      error: { kind: "http-error", status: 302 },
+    });
+  });
+
+  it("postはリダイレクト先を理由に添える", async () => {
+    mockFetch.mockResolvedValue(redirectResponse);
+
+    const result = await httpClient.post(config);
+
+    expect(result.type).toBe("error");
+    if (result.type !== "error" || result.error.kind !== "http-error") {
+      throw new Error("unexpected result");
+    }
+    expect(result.error.message).toContain("Redirect");
+    expect(result.error.message).toContain("https://example.com/login");
+  });
+
+  it("postStreamはリダイレクトを追わない", async () => {
+    mockFetch.mockResolvedValue(redirectResponse);
+
+    const chunks = [];
+    for await (const chunk of httpClient.postStream(config)) {
+      chunks.push(chunk);
+    }
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://example.com/api",
+      expect.objectContaining({ redirect: "manual" }),
+    );
+    expect(chunks[0]).toMatchObject({
+      type: "error",
+      error: { kind: "http-error", status: 302 },
     });
   });
 });

--- a/src/libs/http/http-client.ts
+++ b/src/libs/http/http-client.ts
@@ -1,6 +1,7 @@
 import { logger } from "../logging/logger.js";
 import type {
   HttpClient,
+  HttpError,
   HttpRequestConfig,
   HttpResponse,
   StreamChunk,
@@ -13,6 +14,18 @@ const extractHeaders = (headers: Headers): Record<string, string> => {
   });
   return result;
 };
+
+const isRedirect = (status: number): boolean => status >= 300 && status < 400;
+
+// リダイレクトを追うと、ランタイムは Authorization を落とすが独自ヘッダは落とさない。
+// 呼び出し側が資格情報を独自ヘッダで渡している場合、それが転送先のオリジンに渡る。
+const redirectError = (response: Response): HttpError => ({
+  kind: "http-error",
+  status: response.status,
+  message: `Redirect not followed (HTTP ${response.status} ${response.statusText}) to ${
+    response.headers.get("location") ?? "unknown location"
+  }. Forwarded credentials must not reach another origin.`,
+});
 
 const safeReadResponseText = async (response: Response): Promise<string> => {
   try {
@@ -40,11 +53,16 @@ const post = async (config: HttpRequestConfig): Promise<HttpResponse> => {
       },
       body: JSON.stringify(config.body),
       signal: controller.signal,
+      redirect: "manual",
     });
 
     clearTimeout(timeoutId);
 
     const responseHeaders = extractHeaders(response.headers);
+
+    if (isRedirect(response.status)) {
+      return { type: "error", error: redirectError(response) };
+    }
 
     if (!response.ok) {
       const errorBody = await safeReadResponseText(response);
@@ -178,9 +196,15 @@ async function* postStream(
       },
       body: JSON.stringify(config.body),
       signal: controller.signal,
+      redirect: "manual",
     });
 
     clearTimeout(timeoutId);
+
+    if (isRedirect(response.status)) {
+      yield { type: "error", error: redirectError(response) };
+      return;
+    }
 
     if (!response.ok) {
       const errorBody = await safeReadResponseText(response);


### PR DESCRIPTION
## 問題

`--forward-impersonator-token` を使うと `X-Impersonator-Id-Token` に利用者本人の ID token が入りますが、`fetch` に `redirect` オプションを渡していないため Node の既定でリダイレクトを追います。

このとき `Authorization` はランタイムが仕様どおり落としますが、**独自ヘッダは保持されます**。したがってリダイレクトを追うと、転送先のオリジンに利用者の ID token が渡ります。

認証プロキシの後ろにあるエンドポイントを指定する構成では、未認証のリクエストに対して認証画面へのリダイレクトが返ることがあり、条件が揃えば他オリジンへ届きます。

## 変更

`fetch` に `redirect: "manual"` を渡し、3xx を受け取ったら追わずに `http-error` として返します。

```
Redirect not followed (HTTP 302 Found) to https://example.com/login.
Forwarded credentials must not reach another origin.
```

`redirect: "error"` でも漏れは止まりますが、`TypeError: fetch failed` になって理由が分からなくなるため、ステータスと `Location` を添えられる `manual` を選びました。MCP のエンドポイントがリダイレクトを返すのは正常系ではないので、追わずにエラーにするのが妥当だと考えています。

`post` と `postStream` の両方に入れています。

## テスト

`src/libs/http/http-client.test.ts` に3件追加しました。

- `post` がリダイレクトを追わない（`redirect: "manual"` が渡り、302 が `http-error` になる）
- エラーメッセージにリダイレクト先が入る
- `postStream` も同じ

既存の `toHaveBeenCalledWith` は `redirect: "manual"` を含む形に更新しています。

## 確認

- `vitest run`: 94 passed / 13 skipped
- `biome check`: クリーン
- `tsc --noEmit`: 2件のエラーが出ますが、`mcp-server-handlers.ts` と `mcp-server-simple.ts` の SDK 型に関するもので、この変更の前後で同じです（手元は bun ではなく npm で依存を入れたため、SDK が新しく解決されたことによるものと思われます）

## 補足

`redirect: "manual"` は挙動の変更になります。リダイレクトを前提にしたエンドポイントを指定している利用者がいる場合は影響します。オプションで選べる形が望ましいということであれば、そのように直します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)